### PR TITLE
Enable filtering of notification email template

### DIFF
--- a/comment-notifier-no-spammers.php
+++ b/comment-notifier-no-spammers.php
@@ -263,7 +263,7 @@ function lstc_notify( $comment_id ) {
 	$ok = 0;
 	foreach ( $subscriptions as $subscription ) {
 		$idx++;
-		$m = $message;
+		$m = apply_filters( 'lstc_notify_message', $message, $comment, $subscription );
 		$m = str_replace('{name}', $subscription->name, $m);
 		$m = str_replace('{unsubscribe}', $url . 'lstc_id=' . $subscription->id . '&lstc_t=' . $subscription->token, $m);
 		$s = $subject;


### PR DESCRIPTION
Firstly, thanks so much for building and maintaining this plugin!

While setting this up for a client I found one limitation that prevented me from doing what I needed to do: change the email content based on the comment and subscriber info. 

In this PR I added a filter with access to the comment and subscriber objects, which will let devs customize the notification message as needed.